### PR TITLE
Response handler

### DIFF
--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -82,22 +82,20 @@ class HM_Rewrite {
 	/**
 	 * Do a response to a request
 	 *
-	 * @param string  $status         'success', 'error', or a custom status
+	 * @param int     $status_header  HTTP status header
 	 * @param string  $message        Message to include with response (optional)
-	 * @param int     $status_header  HTTP status header (optional)
 	 */
-	public static function do_json_response( $status, $message = '', $status_header = false ) {
+	public static function do_response( $status, $message = '' ) {
 
-		if ( ! $status_header ) {
-			if ( 'success' == $status )
-				$status_header = 200;
-			else
-				$status_header = 405;
+		status_header( (int)$status );
+
+		if ( ! empty( $message ) &&
+		 ( is_object( $message ) || is_array( $message ) ) ) {
+			header( 'Content-Type: application/json' );
+			$message = json_encode( $message );
 		}
 
-		header( 'Content-Type: application/json' );
-		status_header( (int)$status_header );
-		echo json_encode( array( 'status' => $status, 'message' => $message ) );
+		echo $message;
 		exit;
 	}
 
@@ -168,7 +166,7 @@ class HM_Rewrite_Rule {
 
 		// check request methods match
 		if ( $this->request_methods && ! in_array( strtolower( $_SERVER['REQUEST_METHOD'] ), $this->request_methods ) ) {
-			HM_Rewrite::do_json_response( 'error', 'Invalid request method', 403 );
+			HM_Rewrite::do_response( 403, 'Invalid request method' );
 		}
 
 		do_action( 'hm_parse_request_' . $this->get_regex(), $wp );


### PR DESCRIPTION
Instead of having response handlers like this in our code:

```
+      if ( ! $poll ) {
+        header( "HTTP/1.0 500 Internal Server Error" );
+        echo json_encode( array( 'success' => false, 'message' => __( 'There was an unexpected error when creating the poll', 'WPPP' ) ) );
+        exit;
+      }
```

It should be an API provided in hm-rewrite.

From https://github.com/tcrsavage/wp-pretty-polls/commit/a1bf15d25851f0bd95df1bec7264c6a3231ad183#L3R12
