### PR TITLE
Use locale_template

### DIFF
--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -206,7 +206,7 @@ class HM_Rewrite_Rule {
 
 			if ( $t->template ) {
 
-				locate_template( $t -> template, true);
+				locate_template( $t->template, true);
 				exit;
 			}
 		});


### PR DESCRIPTION
Hello,

I think you can use the method 'locate_template' for managing parent/child themes, in your template_redirect.

http://codex.wordpress.org/Function_Reference/locate_template

Thanks a lot :)
