### PR TITLE
No way to bail from a request

### DIFF
--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -152,8 +152,17 @@ class HM_Rewrite_Rule {
 
 		do_action( 'hm_parse_request_' . $this->get_regex(), $wp );
 
-		foreach ( $this->request_callbacks as $callback )
-			call_user_func_array( $callback, array( $wp ) );
+		$bail = false;
+		foreach ( $this->request_callbacks as $callback ) {
+			$return = call_user_func_array( $callback, array( $wp ) );
+
+			// Avoid counting `null`/no return as an error
+			$bail |= ( $return === false );
+		}
+
+		// If a callback returned false, bail from the request
+		if ( $bail )
+			return;
 
 		$t = $this;
 


### PR DESCRIPTION
If I register a rewrite for (e.g.) `/foo/(.+)`, I'd like to be able to check the value in my request callback and fall back to a 404 page if it's not set.

Setting `$wp->query_vars['error'] = '404';` will send the 404 status code, but doesn't stop HM Rewrite from hooking into the various pieces and taking over the request.

This could be handled via either a try-catch block around the request callback calls, or by checking the result of the calls and, if they return false, passing out of the stack before the request is hijacked.
