### PR TITLE
Add automatic flushing of rewrites

### DIFF
--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -510,22 +510,30 @@ add_filter( 'query_vars', function( $query_vars ) {
 
 } );
 
+/**
+ * Flush rewrite rules, without deleting the option
+ *
+ * Uses `update_option` without first using `delete_option`, allowing it to run
+ * on every request.
+ */
+function hm_rewrite_flush() {
+	do_action( 'hm_rewrite_before_flush' );
+
+	global $wp_rewrite;
+	$wp_rewrite->matches = 'matches';
+	$rules = $wp_rewrite->rewrite_rules( true );
+
+	if ( update_option( 'rewrite_rules', $rules ) ) {
+		do_action( 'hm_rewrite_flushed', $rules );
+	}
+	else {
+		do_action( 'hm_rewrite_cached', $rules );
+	}
+}
+
 if ( HM_REWRITE_AUTOFLUSH ) {
 	/**
 	 * Automatically flush rewrite rules when they're changed
 	 */
-	add_action( 'wp_loaded', function() {
-		do_action( 'hm_rewrite_before_flush' );
-
-		global $wp_rewrite;
-		$wp_rewrite->matches = 'matches';
-		$rules = $wp_rewrite->rewrite_rules( true );
-
-		if ( update_option( 'rewrite_rules', $rules ) ) {
-			do_action( 'hm_rewrite_flushed', $rules );
-		}
-		else {
-			do_action( 'hm_rewrite_cached', $rules );
-		}
-	}, 9999 );
+	add_action( 'wp_loaded', 'hm_rewrite_flush', 9999 );
 }


### PR DESCRIPTION
This automatically flushes rewrite rules when they need to be. It does this by "generating" them on every request, which could potentially theoretically be slow.

In practice, the slowest part of rewrite rules is deleting the option, and then saving it again, which WP does every time you call `flush_rewrite_rules`. If your rewrites haven't changed, deleting the option is unnecessary, as `update_option` can work out whether it needs to actually update the DB/object cache.

This PR automatically flushes rewrite rules for you, if you define `HM_REWRITE_AUTOFLUSH` as true. This currently defaults to false for backwards compatibility reasons, but setting it to true would be my preferred option.

My findings in practice: there are 179 rules in use on Happytables. This adds ~3ms to page loads, which is negligible at best.
