### PR TITLE
Supports title tag for WordPress 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "humanmade/hm-rewrite",
+  "description": "HM_Rewrite is a wrapper for the WordPress WP Rewrite system. http://hmn.md/wordpress-rewrite-rules-hm-core-style/",
+  "type": "wordpress-muplugin",
+  "require": {
+    "php": ">=5.2",
+    "composer/installers": "~1.0"
+  },
+  "license": "GPLv2",
+  "authors": [
+    {
+      "name": "Human Made Limited",
+      "email": "support@humanmade.co.uk"
+    }
+  ]
+}

--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -275,27 +275,29 @@ class HM_Rewrite_Rule {
 		 */
 		if ( current_theme_supports( 'title-tag' ) ) {
 
-			add_filter( 'pre_get_document_title', function( $title ) use ( $t ) {
+			add_filter( 'pre_get_document_title', function ( $title ) use ( $t ) {
 
 				$sep = apply_filters( 'document_title_separator', '-' );
 
-				foreach ( $t->title_callbacks as $callback )
+				foreach ( $t->title_callbacks as $callback ) {
 					$title = call_user_func_array( $callback, array( $title, $sep ) );
+				}
 
 				return $title;
 
 			} );
 
 		} else {
-			add_filter( 'wp_title', function( $title, $sep = '' ) use ( $t ) {
+			add_filter( 'wp_title', function ( $title, $sep = '' ) use ( $t ) {
 
-				foreach ( $t->title_callbacks as $callback )
+				foreach ( $t->title_callbacks as $callback ) {
 					$title = call_user_func_array( $callback, array( $title, $sep ) );
-
+				}
+				
 				return $title;
 
-			}, 10, 2 );
-
+			}, 10, 2 ); 
+			
 		}
 
 		add_action( 'admin_bar_menu', function() use ( $t ) {


### PR DESCRIPTION
Since 4.4.0 WP allows theme support for title tag so title_callback won't work. This patch fixes it with new filters.