### PR TITLE
fix title execution priority for WP SEO compatibility

### DIFF
--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -285,7 +285,7 @@ class HM_Rewrite_Rule {
 
 				return $title;
 
-			} );
+			}, 20 );
 
 		} else {
 			add_filter( 'wp_title', function ( $title, $sep = '' ) use ( $t ) {
@@ -296,7 +296,7 @@ class HM_Rewrite_Rule {
 				
 				return $title;
 
-			}, 10, 2 ); 
+			}, 20, 2 );
 			
 		}
 


### PR DESCRIPTION
for compatibility with yoasts WP SEO, the execution priority has to be bigger than 15

`pre_get_document_title`
https://github.com/Yoast/wordpress-seo/blob/trunk/frontend/class-frontend.php#L103

`wp_title`
https://github.com/Yoast/wordpress-seo/blob/trunk/frontend/class-frontend.php#L104