### PR TITLE
Add an integration layer with the Rewrite Rule Testing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ hm_add_rewrite_rule( array(
   },
   'title_callback' => function( $title, $seperator ) {
     return review_category . ' ' . $seperator . ' ' . $title;
+  },
+  'rewrite_tests_callback' => function() {
+    return array(
+      'Review Category' => array(
+        '/reviews/foo/',
+        '/reviews/bar/',
+      ),
+    );
   }
 ) );
 ```

--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -584,12 +584,12 @@ add_filter( 'rewrite_testing_tests', function( array $tests ) {
 
 		$args = $rule->get_wp_query_args();
 
-		foreach ( $rule_tests as $group => $rule_tests ) {
+		foreach ( $rule_tests as $group => $group_tests ) {
 			if ( ! isset( $tests[ $group ] ) ) {
 				$tests[ $group ] = array();
 			}
 
-			foreach ( $rule_tests as $rule_test ) {
+			foreach ( $group_tests as $rule_test ) {
 				$tests[ $group ][ $rule_test ] = $args;
 			}
 		}

--- a/hm-rewrites.php
+++ b/hm-rewrites.php
@@ -109,7 +109,7 @@ class HM_Rewrite_Rule {
 	public $template = '';
 	public $access_rule = '';
 	public $request_methods = array();
-	public $rewrite_tests = null;
+	public $rewrite_tests_callback = null;
 	public $disable_canonical = false;
 
 	public function __construct( $regex, $id = null ) {
@@ -156,18 +156,18 @@ class HM_Rewrite_Rule {
 	 * @return void
 	 */
 	public function set_rewrite_tests_callback( $callback ) {
-		$this->rewrite_tests = $callback;
+		$this->rewrite_tests_callback = $callback;
 	}
 
 	/**
 	 * @return array<string, string[]>
 	 */
 	public function get_rewrite_tests() {
-		if ( null === $this->rewrite_tests ) {
+		if ( null === $this->rewrite_tests_callback ) {
 			return array();
 		}
 
-		return call_user_func( $this->rewrite_tests );
+		return call_user_func( $this->rewrite_tests_callback );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #17 

This allows rewrites to specify an array of test URLs that get matched against the expected query args when [the Rewrite Rule Testing plugin](https://github.com/alleyinteractive/rewrite-testing) is in use.

Example:

```php
hm_add_rewrite_rule( array(
  'regex'    => '^reviews/([^/]+)/?',
  'query'    => 'review_category=$matches[1]',
  'template' => 'review-category.php',
  'rewrite_tests_callback' => function() {
    return array(
      'Review Category' => array(
        '/reviews/foo/',
        '/reviews/bar/',
      ),
    );
  }
) );
```